### PR TITLE
Fix security problem with HTTP download

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -36,7 +36,7 @@ apps:
     environment:
       WINEPREFIX: "$SNAP_USER_COMMON/.wine"
       DLLOVERRIDES: "mshtml=" # Prevent pop-ups about Wine Gecko
-      INSTALL_URL_TS: "http://tore29.com/tsins/TSinstaller.exe" # cnctsun full game setup
+      INSTALL_URL_TS: "https://tore29.com/tsins/TSinstaller.exe" # cnctsun full game setup
       INSTALL_URL_CNC: "https://downloads.cncnet.org/TiberianSun_Online_Installer.exe" # cnctsun multiplayer only setup
       MONO_URL: "https://dl.winehq.org/wine/wine-mono/4.7.1/wine-mono-4.7.1.msi"
       TRICKS: "dotnet20"


### PR DESCRIPTION
This PR changes the URL from HTTP to HTTPS to avoid a malicious middle-man to intercept the download and provide a malicious EXE instead.